### PR TITLE
Process all frames on the stack even if some error out.  Added option…

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,34 +6,39 @@ const fs = require('fs-extra');
 const clipboardy = require('clipboardy');
 const { SourceMapConsumer } = require('source-map');
 
-
 const cli = meow(`
 	Usage
 	  $ stacktracify <map-path>
 
 	Options
     --file, -f  (default is read from clipboard)
+	  --stoponfirst -s (stop processing stack on first error)
 
 	Examples
 	  $ stacktracify /path/to/js.map --file /path/to/my-stacktrace.txt
+	  $ stacktracify /path/to/js.map --file /path/to/my-stacktrace.txt --stoponfirst
 `, {
-	flags: {
-		file: {
-			type: 'string',
-			alias: 'f',
-		}
-	}
+  flags: {
+    file: {
+      type: 'string',
+      alias: 'f',
+    },
+    stoponfirst: {
+      type: 'boolean',
+      alias: 's',
+    },
+  }
 });
 
 
 const file = cli.flags.file;
+const stoponfirst = cli.flags.stoponfirst;
 
 (async () => {
   try {
     const mapPath = cli.input[0];
     if (!mapPath) cli.showHelp();
     const mapContent = JSON.parse(await fs.readFile(mapPath, 'utf-8'));
-    // WTF? promise?
     const smc = await new SourceMapConsumer(mapContent);
 
     let str;
@@ -49,14 +54,24 @@ const file = cli.flags.file;
 
     if (header) console.log(header);
 
+    var errString = '';
     stack.forEach(({ lineNumber, column }) => {
-      const pos = smc.originalPositionFor({ line: lineNumber, column });
-      if (pos && pos.line != null) {
-        console.log(`    at ${pos.name || ''} (${pos.source}:${pos.line}:${pos.column})`);
+      try {
+        const pos = smc.originalPositionFor({ line: lineNumber, column });
+        if (pos && pos.line != null) {
+          console.log(`    at ${pos.name || ''} (${pos.source}:${pos.line}:${pos.column})`);
+        }
+      } catch (err) {
+        if (stoponfirst) {
+          throw (err);
+        }
+        errString += err.stack;
       }
-
-      // console.log('src', smc.sourceContentFor(pos.source));
     });
+
+    if (errString.length > 0) {
+      console.error(errString);
+    }
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
PURPOSE OF MODIFICATION:
There was a frame in the middle of my stack that BasicSourceMapConsumer.originalPositionFor was erroring out on (no line# in this case), but I had more frames in the stack that I was curious if BasicSourceMapConsumer.originalPositionFor could get positions for.  It can in my cases.  Unfortunately, I can't provide the map to proprietary code to help with this example, but I think the code makes sense.  There are other options that could of been implemented for this specific example, but I like the idea of processing the next frame regardless of what error the consumer comes up with for the current frame.    

EXAMPLE STACK: 
TypeError: Cannot read property 'IsCompleteFlag' of undefined
  at Module.p(x.js:1:2789898)
  at ? (x.js:1:746448)
  at Array.forEach(<anonymous>)
  at Ci(x.js:1:746410)
  at ? (x.js:1:746256)
  at ? (x.js:1:742338)
  at Object.next(x.js:1:742443)
  at o(x.js:1:741211)
  
ORIGINAL OUTPUT: 
Stops at at Array.forEach(<anonymous>).
> stacktracify .\WorkAreaKeepOut\main.9c2573c77290926e9a91.chunk.js.map --file .\WorkAreaKeepOut\UglyTraceOrig.txt
    at IsCompleteFlag (DigiDataServiceAPI/Activity/Activity.ts:61:19)
    at IsTodayTomorrowAppointment (store/states/Activity/ActivityActionCreator.ts:323:45)
Error: Line numbers must be >= 1
    at BasicSourceMapConsumer.originalPositionFor (C:\Users\x\AppData\Roaming\npm\node_modules\stacktracify\node_modules\source-map\lib\source-map-consumer.js:495:13)
    at stack.forEach (C:\Users\x\AppData\Roaming\npm\node_modules\stacktracify\index.js:53:23)
    at Array.forEach (<anonymous>)
    at C:\Users\x\AppData\Roaming\npm\node_modules\stacktracify\index.js:52:11
	
MODIFIED OUTPUT: 
Keeps going past at Array.forEach(<anonymous>) (or anything else that might error out).  
> stacktracify .\WorkAreaKeepOut\main.9c2573c77290926e9a91.chunk.js.map --file .\WorkAreaKeepOut\UglyTraceOrig.txt
TypeError: Cannot read property 'IsCompleteFlag' of undefined
    at IsCompleteFlag (x/xy/xyz.ts:61:19)
    at IsTodayTomorrowAppointment (x/xy/xyz/a.ts:323:45)
    at forEach (x/xy/xyz/a.ts:322:15)
    at updateAppointmentActivityCounts (x/xy/xyz/a.ts:309:16)    
	at  (m/n/o.ts:8:0)
    at  (m/n/o.ts:8:0)
    at  (m/n/o.ts:8:0)
Error: Line numbers must be >= 1
    at BasicSourceMapConsumer.originalPositionFor (C:\Users\x\AppData\Roaming\npm\node_modules\stacktracify\node_modules\source-map\lib\source-map-consumer.js:495:13)
    at stack.forEach (C:\Users\x\AppData\Roaming\npm\node_modules\stacktracify\index.js:61:21)
    at Array.forEach (<anonymous>)
    at C:\Users\x\AppData\Roaming\npm\node_modules\stacktracify\index.js:59:11
	
CAN STILL GET ORIGINAL OUTPUT WITH OPTION:
> stacktracify .\WorkAreaKeepOut\main.9c2573c77290926e9a91.chunk.js.map --file .\WorkAreaKeepOut\UglyTraceOrig.txt --stoponfirst
    at IsCompleteFlag (DigiDataServiceAPI/Activity/Activity.ts:61:19)
    at IsTodayTomorrowAppointment (store/states/Activity/ActivityActionCreator.ts:323:45)
Error: Line numbers must be >= 1
    at BasicSourceMapConsumer.originalPositionFor (C:\Users\x\AppData\Roaming\npm\node_modules\stacktracify\node_modules\source-map\lib\source-map-consumer.js:495:13)
    at stack.forEach (C:\Users\x\AppData\Roaming\npm\node_modules\stacktracify\index.js:53:23)
    at Array.forEach (<anonymous>)
    at C:\Users\x\AppData\Roaming\npm\node_modules\stacktracify\index.js:52:11
	

  
  
