### PR TITLE
Fallback to methodName before [unknown]

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ const { file } = cli.flags;
         } else {
           const pos = smc.originalPositionFor({ line: lineNumber, column });
           if (pos && pos.line != null) {
-            console.log(`    at ${pos.name || '[unknown]'} (${pos.source}:${pos.line}:${pos.column})`);
+            console.log(`    at ${pos.name || methodName || '[unknown]'} (${pos.source}:${pos.line}:${pos.column})`);
           }
     
           // console.log('src', smc.sourceContentFor(pos.source));


### PR DESCRIPTION
My bundled code is a few lines offset from the original source code, so `originalPositionFor` isn't able to find the method. My stack trace, however, has the correct method name, so I think it is better to display that rather than `[unknown]`.