### PR TITLE
fix: add SourceMapConsumer cleanup, handle unmapped and bare stack lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ const { file } = cli.flags;
 const mapPath = cli.input[0];
 if (!mapPath) cli.showHelp();
 const mapContent = JSON.parse(await readFile(mapPath, 'utf8'));
-// WTF? promise?
 const smc = await new SourceMapConsumer(mapContent);
 
 let str;
@@ -52,6 +51,12 @@ lines = lines.map((line) => {
     return `${match[1]}at ${match[3]} (${match[2]})`;
   }
 
+  // handle lines with no method name: '    file:line:col' or '    file:line:col '
+  const matchNoMethod = line.match(/^(\s+)([^\s]+:\d+:\d+)\s*$/);
+  if (matchNoMethod) {
+    return `${matchNoMethod[1]}at <unknown> (${matchNoMethod[2]})`;
+  }
+
   return line;
 })
 
@@ -60,19 +65,23 @@ if (stack.length === 0) throw new Error('No stack found');
 
 if (header) console.log(header);
 
-stack.forEach(({ methodName, lineNumber, column }) => {
-  try {
-    if (lineNumber == null || lineNumber < 1) {
-      console.log(`    at ${methodName || '[unknown]'}`);
-    } else {
-      const pos = smc.originalPositionFor({ line: lineNumber, column });
-      if (pos && pos.line != null) {
-        console.log(`    at ${pos.name || methodName || '[unknown]'} (${pos.source}:${pos.line}:${pos.column})`);
+try {
+  stack.forEach(({ methodName, lineNumber, column }) => {
+    try {
+      if (lineNumber == null || lineNumber < 1) {
+        console.log(`    at ${methodName || '[unknown]'}`);
+      } else {
+        const pos = smc.originalPositionFor({ line: lineNumber, column });
+        if (pos && pos.line != null) {
+          console.log(`    at ${pos.name || methodName || '[unknown]'} (${pos.source}:${pos.line}:${pos.column})`);
+        } else {
+          console.log(`    at ${methodName || '[unknown]'} (line ${lineNumber}:${column})`);
+        }
       }
-
-      // console.log('src', smc.sourceContentFor(pos.source));
+    } catch (err) {
+      console.log(`    at FAILED_TO_PARSE_LINE`);
     }
-  } catch (err) {
-    console.log(`    at FAILED_TO_PARSE_LINE`);
-  }
-});
+  });
+} finally {
+  smc.destroy();
+}


### PR DESCRIPTION
- Call `smc.destroy()` after use to free WASM memory allocated by `source-map`
- Show unmapped positions instead of silently dropping stack lines with no source map entry
- Handle `file:line:col` stack lines that have no method name (e.g from react native traces)
- Remove leftover dev comment

What was wrong and why:

1) Missing `smc.destroy()` <- WASM memory leak
`source-map`'s `SourceMapConsumer` allocates WASM memory that must be explicitly freed via `destroy()`, the call was missing entirely

2) Silent line drops when source map has no mapping
When `smc.originalPositionFor()` returns `{ line: null }` the code produced zero output for that stack frame, users see gaps in their translated trace with no indication a line was present but unmapped. Now falls back to printing: `atmethodName (line N:col)`

3) Bare `file:line:col` lines parsed with leading whitespace in filename
 Stack traces from React Native include lines like:

      main.jsbundle:954:5353

(no method name, trailing space). The existing regex only matched `file:line:col method`, these bare lines fell through to `stacktrace-parser` which included leading whitespace in the filename which ended up causing `originalPositionFor` to silently fail so added a second regex to reformat these as `at <unknown> (file:line:col)`